### PR TITLE
Make sure special chars are displayed correctly

### DIFF
--- a/Urlchecker.botplug.js
+++ b/Urlchecker.botplug.js
@@ -1,5 +1,7 @@
 'use strict';
-var request = require( 'request' ),
+var jschardet = require( 'jschardet' ),
+    iconv = require( 'iconv-lite' ),
+    request = require( 'request' ),
     cheerio = require( 'cheerio' ),
     urlChecker = {
         bot : false,
@@ -19,6 +21,7 @@ var request = require( 'request' ),
             var url,
                 urlRegex = /(https?:\/\/[^\s]+)/g,
                 options = {
+                    encoding: null,
                     headers: {
                         'User-Agent': 'request'
                     }
@@ -29,12 +32,17 @@ var request = require( 'request' ),
             if( url !== null ){
                 options.url = url[ 0 ];
                 request( options, function( error, response, html ){
-                    var $ = cheerio.load( html ),
-                        pageTitle;
+                    var encoding = jschardet.detect( html ),
+                        pageTitle,
+                        $;
 
                     if( error ){
                         console.log( error );
                     }
+
+                    // Make sure special chars are displayed correctly
+                    html = iconv.decode( html, encoding.encoding );
+                    $ = cheerio.load( html );
 
                     pageTitle = $( 'title' ).text();
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   "license": "MIT",
   "dependencies": {
     "cheerio": "^0.19.0",
+    "iconv-lite": "^0.4.13",
     "irc": ">=0.3.9",
+    "jschardet": "^1.4.1",
     "node-twitter-api": "^1.5.0",
     "pushbullet": ">=1.4.3",
     "request": "^2.57.0"


### PR DESCRIPTION
Make sure the title from sites using another encoding than UTF-8 display special chars such as "Å", "Ä", and "Ö" correctly.