### PR TITLE
Just tell the channel about created pull requests, not everything

### DIFF
--- a/GitHub.botplug.js
+++ b/GitHub.botplug.js
@@ -111,7 +111,13 @@ var https = require( 'https' ),
                         }
                         break;
                     case 'PullRequestEvent' :
-                        message = this.users[ user ].nick + ' created a pull request for ' + responseData[ 0 ].repo.html_url + ' titled "' + responseData[ 0 ].payload.pull_request.title + '"';
+                        switch( responseData[ 0 ].payload.action ){
+                            case 'opened':
+                                message = this.users[ user ].nick + ' created a pull request for ' + responseData[ 0 ].repo.html_url + ' titled "' + responseData[ 0 ].payload.pull_request.title + '"';
+                                break;
+                            default:
+                                break;
+                        }
                         break;
                     case 'IssuesEvent':
                         switch( responseData[ 0 ].payload.action ){


### PR DESCRIPTION
Right now, we tell the channel that someone created a pull request even when they closed one, just tell the channel about it when someone actually creates one.